### PR TITLE
Patch : use fresh value from database in denormalize_from

### DIFF
--- a/lib/mongoid_denormalize.rb
+++ b/lib/mongoid_denormalize.rb
@@ -56,7 +56,12 @@ module Mongoid::Denormalize
       self.denormalize_definitions.each do |definition|
         next if definition[:options][:to]
         
-        definition[:fields].each { |name| self.send("#{definition[:options][:from]}_#{name}=", self.send(definition[:options][:from]).try(name)) }
+        definition[:fields].each do |name|
+          field = definition[:options][:from]
+          # force reload if :from method is an association ; call it normally otherwise
+          associated =  self.class.reflect_on_association(field) ? self.send(field, true) : self.send(field)
+          self.send("#{field}_#{name}=", associated.try(name))
+        end
       end
     end
     

--- a/spec/mongoid_denormalize_spec.rb
+++ b/spec/mongoid_denormalize_spec.rb
@@ -44,6 +44,12 @@ describe Mongoid::Denormalize do
       
       @post.user_location.should eql @user.location
     end
+
+    it "should use fresh values from database where possible" do
+      @other_post = Post.create!(:title => "My first blog post")
+      @other_post.update_attribute(:user_id, @user.id)
+      @other_post.user_name.should eql @user.name
+    end
     
     it "should update denormalized values if attribute is changed" do
       @user.update_attributes(:name => "Bob Doe", :location => [4, 4])


### PR DESCRIPTION
It's pretty common in web applications to update the `<referenced>_id` field directly for updating associations. In this case, mongoid_denormalize doesn't behave like expected because it trusts Mongoid's association cache, which is not reliable. Technically, mongoid_denormalize uses `MyModel#<referenced>`, which will fetch the `@<referenced>` instance variable, which can be out of sync. Using `MyModel#<referenced>(true)` forces a reload from the database.

So I think mongoid_denormalize should try to hit database when possible (e.g. when the specified field is actually an association, and not a custom method from the model).

Just see the spec for an actual example, it fails without the proposed patch. Let me know what you think.
