### PR TITLE
only push denormalize_to changes if the field is dirty

### DIFF
--- a/spec/mongoid_denormalize_spec.rb
+++ b/spec/mongoid_denormalize_spec.rb
@@ -94,6 +94,11 @@ describe Mongoid::Denormalize do
       @moderated_comment.reload
       @moderated_comment.moderator_nickname.should eql "jonsey"
     end
+
+    it "shouldn't make superfluous saves" do
+      @comment.should_not_receive(:save)
+      @post.save!
+    end
   end
   
   context "rake task" do


### PR DESCRIPTION
If I understand correctly, `denormalize_to` only gets used if the from side is modified. If you're denormalizing usernames into posts, then adding a post gets handled by `denormalize_from`. It's just `post.username = 'bob'` that requires the `to` side. So it seems to me that you can avoid doing a lot of extra saves on the child elements by only having `denormalize_to` do any work when the relevant fields have been updated. This pull requests does that.
