### PR TITLE
Fix Ruby 2.0.0 warnings

### DIFF
--- a/lib/mongoid_denormalize.rb
+++ b/lib/mongoid_denormalize.rb
@@ -103,12 +103,12 @@ module Mongoid::Denormalize
   end
 
   def assign_and_save(obj, assignments, prefix)
-    attributes_hash = Hash[assignments.collect do |assignment|
+    attributes_hash = Hash[assignments.collect { |assignment|
       if self.changed_attributes.has_key?(assignment[:source_field].to_s) ||
           self.changed_attributes.has_key?(assignment[:source_field].to_sym)
         ["#{prefix}_#{assignment[:source_field]}", assignment[:value]]
       end
-    end]
+    }.compact]
     
     unless attributes_hash.empty?
       # The more succinct update_attributes(changes, :without_protection => true) requires Mongoid 3.0.0, 


### PR DESCRIPTION
On Ruby 2.0.0, I get warnings as follows:

```
/Users/chrishol/code/git-clones/mongoid_denormalize/lib/mongoid_denormalize.rb:106: warning: wrong element type nil at 0 (expected array)
/Users/chrishol/code/git-clones/mongoid_denormalize/lib/mongoid_denormalize.rb:106: warning: ignoring wrong elements is deprecated, remove them explicitly
/Users/chrishol/code/git-clones/mongoid_denormalize/lib/mongoid_denormalize.rb:106: warning: this causes ArgumentError in the next release
```

Compacting the array before doing Hash[...] avoids nils and removes the warnings.
